### PR TITLE
Clarify installation and update guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,30 @@ path traversal vulnerabilities.
 ## Requirements
 
 * Python 3.10+
-* Dependencies: `httpx[socks]`, `rich`, `rich-argparse`
+* Git
+* Dependencies: `httpx[socks]`, `rich`, `rich-argparse`, and
+  `tomli` on Python 3.10
 
 ## Installation
 
 ```bash
 git clone https://github.com/lightos/Panoptic.git
 cd Panoptic
-pip install -e .
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .
+panoptic --version
 ```
+
+On Windows, activate with `.venv\Scripts\activate`. The editable install
+keeps Panoptic connected to this checkout for `--update`, so keep the
+directory in place. Do not run `pip install panoptic`: that PyPI name
+belongs to an unrelated project.
 
 For development:
 
 ```bash
-pip install -e ".[dev]"
+python -m pip install -e ".[dev]"
 ```
 
 ## Usage
@@ -343,10 +353,16 @@ panoptic --update    # fast-forward update from the official GitHub repo
 `--update` only works from a git checkout whose `origin` remote uses
 HTTPS or SSH and matches the official upstream (verified before pulling,
 to resist insecure or tampered remote configuration). It fast-forwards
-the checked-out `main` branch from the explicit upstream `main` ref; for
-pip installs it prints the correct
-`pip install -U` command instead. When run from a checkout, the banner
-also shows the current short git revision.
+the checked-out `main` branch from the explicit upstream `main` ref.
+Non-checkout installations can be refreshed safely from the official
+GitHub archive:
+
+```bash
+python -m pip install --upgrade https://github.com/lightos/Panoptic/archive/refs/heads/main.zip
+```
+
+When run from a checkout, the banner also shows the current short git
+revision.
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ python -m pip install -e .
 panoptic --version
 ```
 
-On Windows, activate with `.venv\Scripts\activate`. The editable install
-keeps Panoptic connected to this checkout for `--update`, so keep the
-directory in place. Do not run `pip install panoptic`: that PyPI name
-belongs to an unrelated project.
+On Windows Command Prompt, activate with `.venv\Scripts\activate.bat`;
+in PowerShell, use `.venv\Scripts\Activate.ps1`. The editable install keeps
+Panoptic connected to this checkout for `--update`, so keep the directory
+in place. Do not run `pip install panoptic`: that PyPI name belongs to an
+unrelated project.
 
 For development:
 

--- a/panoptic/update.py
+++ b/panoptic/update.py
@@ -14,6 +14,8 @@ from urllib.parse import urlsplit
 GIT_REPOSITORY_URL = "https://github.com/lightos/Panoptic.git"
 GIT_UPSTREAM_BRANCH = "main"
 GIT_UPSTREAM_REF = f"refs/heads/{GIT_UPSTREAM_BRANCH}"
+PIP_UPDATE_URL = f"https://github.com/lightos/Panoptic/archive/refs/heads/{GIT_UPSTREAM_BRANCH}.zip"
+PIP_UPDATE_COMMAND = f"python -m pip install --upgrade {PIP_UPDATE_URL}"
 
 _PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 _PROJECT_ROOT = os.path.dirname(_PACKAGE_DIR)
@@ -51,7 +53,7 @@ def do_update() -> int:
 
     if not os.path.exists(git_dir):
         print("[i] Panoptic appears to be installed via pip.")
-        print("[i] To update, run: pip install -U panoptic")
+        print(f"[i] To update, run: {PIP_UPDATE_COMMAND}")
         return 0
 
     print("[i] Checking for updates...")
@@ -67,7 +69,7 @@ def do_update() -> int:
         )
     except FileNotFoundError:
         print("[!] 'git' is not installed or not in PATH.")
-        print("[i] Please install git or update via: pip install -U panoptic")
+        print(f"[i] Please install git or update via: {PIP_UPDATE_COMMAND}")
         return 2
     except subprocess.TimeoutExpired:
         print("[!] Timed out while checking the git remote.")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -7,7 +7,6 @@ import pytest
 
 from panoptic.update import (
     GIT_UPSTREAM_REF,
-    PIP_UPDATE_COMMAND,
     _normalise_git_url,
     _uses_secure_git_transport,
     do_update,
@@ -45,7 +44,9 @@ class TestDoUpdate:
     def test_pip_installed_prints_guidance(self, mock_exists: Any, capsys: pytest.CaptureFixture[str]) -> None:
         assert do_update() == 0
         captured = capsys.readouterr()
-        assert PIP_UPDATE_COMMAND in captured.out
+        assert (
+            "python -m pip install --upgrade https://github.com/lightos/Panoptic/archive/refs/heads/main.zip"
+        ) in captured.out
         assert "pip install -U panoptic" not in captured.out
 
     def test_ssh_and_https_remotes_are_equivalent(self) -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -7,6 +7,7 @@ import pytest
 
 from panoptic.update import (
     GIT_UPSTREAM_REF,
+    PIP_UPDATE_COMMAND,
     _normalise_git_url,
     _uses_secure_git_transport,
     do_update,
@@ -44,7 +45,8 @@ class TestDoUpdate:
     def test_pip_installed_prints_guidance(self, mock_exists: Any, capsys: pytest.CaptureFixture[str]) -> None:
         assert do_update() == 0
         captured = capsys.readouterr()
-        assert "pip" in captured.out.lower()
+        assert PIP_UPDATE_COMMAND in captured.out
+        assert "pip install -U panoptic" not in captured.out
 
     def test_ssh_and_https_remotes_are_equivalent(self) -> None:
         assert _normalise_git_url("git@github.com:lightos/Panoptic.git") == _normalise_git_url(


### PR DESCRIPTION
## Summary

- document installation in an isolated virtual environment
- explain why the editable checkout must remain in place for self-update
- warn that the `panoptic` name on PyPI belongs to an unrelated project
- include the Python 3.10-only `tomli` dependency
- replace unsafe PyPI update guidance with the official GitHub source archive

## Verification

- 270 tests pass
- Ruff, formatting, strict mypy, Markdown lint, and pip-audit pass
- editable installation succeeds on Python 3.10
- official GitHub archive installation succeeds on Python 3.10
- non-editable installs print the official archive update command


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded installation requirements and workflow, including virtual environment activation and Windows-specific guidance.
  * Clarified how updates work for checkout-based vs archive-based installs.
  * Added clearer instructions for installing from the latest branch archive (including `main.zip`).

* **Bug Fixes**
  * Updated displayed upgrade guidance so archive-based refreshes show the exact `python -m pip install --upgrade ...main.zip` command, and the legacy message is no longer shown.

* **Tests**
  * Strengthened coverage to assert the exact upgrade command output and ensure the legacy string is not printed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->